### PR TITLE
sip processor supports incremental updates 

### DIFF
--- a/src/schmib_q/bmbp_pred.c
+++ b/src/schmib_q/bmbp_pred.c
@@ -272,10 +272,9 @@ int IsRareBMBP(BMBPPred *p,
 		}
 	}
 	else if((p->use_low == 1) && (lowcount >= p->wrong_count)) {
-
-printf("lowr: %10.0f %d %f %d %10.0f %f\n",max_ts,
-		lowcount,max_diff,p->wrong_count,
-		ts,value);
+		printf("lowr: %10.0f %d %f %d %10.0f %f\n",max_ts,
+			lowcount,max_diff,p->wrong_count,
+			ts,value);
 		return(1);
 
 	} else {

--- a/src/schmib_q/bmbp_pred.c
+++ b/src/schmib_q/bmbp_pred.c
@@ -273,10 +273,10 @@ int IsRareBMBP(BMBPPred *p,
 		}
 		sd = sqrt(total_v / count);
 		if(value > (mean + 5*sd)) {
-printf("sd rare: %10.0f %f (%10.0f)\n" ,ts,value,max_ts);
+			printf("sd rare: %10.0f %f (%10.0f)\n" ,ts,value,max_ts);
 			return(2); /* discard as outlier */
 		} else {
-printf("bmbp rare: %10.0f %f (%10.0f)\n" ,ts,value,max_ts);
+			printf("bmbp rare: %10.0f %f (%10.0f)\n" ,ts,value,max_ts);
 			return(1);
 		}
 	}
@@ -590,11 +590,11 @@ int ForcBMBPPred(void *ib, double *lowpred, double *highpred)
 	}
 	p->last_index = jbindex;
 	if(p->use_low == 1) {
-        	*lowpred = GetHistoryValue(p->data,jbindex);
-        	*highpred = GetHistoryValue(p->data, GetHistorySize(p->data) - jbindex);
+		*lowpred = GetHistoryValue(p->data,jbindex);
+		*highpred = GetHistoryValue(p->data, GetHistorySize(p->data) - jbindex);
 	} else {
-        	*highpred = GetHistoryValue(p->data,jbindex);
-        	*lowpred = GetHistoryValue(p->data, GetHistorySize(p->data) - jbindex);
+		*highpred = GetHistoryValue(p->data,jbindex);
+		*lowpred = GetHistoryValue(p->data, GetHistorySize(p->data) - jbindex);
 	}
 // printf("COMP %d %f %d\n",jbindex,*highpred,GetHistorySize(p->data));
 // fflush(stdout);

--- a/src/schmib_q/bmbp_pred.c
+++ b/src/schmib_q/bmbp_pred.c
@@ -23,7 +23,7 @@
 #include "lognpred.h"
 #include "weibpred.h"
 
-#define DEBUG_SAVE_RESTORE 1
+#define DEBUG_SAVE_RESTORE 0
 
 void *InitBMBPPred(double quantile, double confidence, int fields)
 {

--- a/src/schmib_q/bmbp_pred.c
+++ b/src/schmib_q/bmbp_pred.c
@@ -151,8 +151,6 @@ int IsRareBMBP(BMBPPred *p,
 	int highcount;
 	int lowcount;
 	double t;
-	int ndx;
-	double *vals;
 	double old_ts;
 	int found;
 	double old_v;
@@ -178,11 +176,9 @@ int IsRareBMBP(BMBPPred *p,
 	 * walk backward in the history list and find the spot
 	 */
 	found = 0;
-	vals = GetFieldValues(p->data->data,J_TS);
-	jrb_rtraverse(jr,p->data->age_list)
+	jrb_rtraverse(jr, p->data->age_list)
 	{
-		ndx = jval_i(jrb_val(jr));
-		old_ts = vals[ndx];
+		old_ts = ((HistoryPoint *)jval_v(jrb_val(jr)))->ts;
 		if(old_ts <= ts)
 		{
 			found = 1;
@@ -210,15 +206,12 @@ int IsRareBMBP(BMBPPred *p,
 	jr = start_jr;
 	while(jr != jrb_nil(p->data->age_list))
 	{
-		ndx = jval_i(jrb_val(jr));
-		vals = GetFieldValues(p->data->data,J_TS);
-		old_ts = vals[ndx];
-		vals = GetFieldValues(p->data->data,J_VALUE);
-		old_v = vals[ndx];
-		vals = GetFieldValues(p->data->data,J_HIGHPRED);
-		old_hp = vals[ndx];
-		vals = GetFieldValues(p->data->data,J_LOWPRED);
-		old_lp = vals[ndx];
+		HistoryPoint *historyPoint = (HistoryPoint *)jval_v(jrb_val(jr));
+		
+		old_ts = historyPoint->ts;
+		old_v = historyPoint->value;
+		old_hp = historyPoint->highpred;
+		old_lp = historyPoint->lowpred;
 
 //		if((UseLow == 0) && ((old_v > old_hp) || (old_v < old_lp)))
 		if((p->use_low == 0) && (old_v > old_hp))
@@ -251,11 +244,10 @@ int IsRareBMBP(BMBPPred *p,
 		total = 0;
 		count = 0;
 		jr = start_jr;
-		vals = GetFieldValues(p->data->data,J_VALUE);
 		while(jr != jrb_nil(p->data->age_list))
 		{
-			ndx = jval_i(jrb_val(jr));
-			old_v = vals[ndx];
+			HistoryPoint *historyPoint = (HistoryPoint *)jval_v(jrb_val(jr));
+			old_v = historyPoint->value;
 			total += old_v;
 			count++;
 			jr = jrb_prev(jr);
@@ -263,11 +255,10 @@ int IsRareBMBP(BMBPPred *p,
 		mean = total / count;
 		total_v = 0;
 		jr = start_jr;
-		vals = GetFieldValues(p->data->data,J_VALUE);
 		while(jr != jrb_nil(p->data->age_list))
 		{
-			ndx = jval_i(jrb_val(jr));
-			old_v = vals[ndx];
+			HistoryPoint *historyPoint = (HistoryPoint *)jval_v(jrb_val(jr));
+			old_v = historyPoint->value;
 			total_v += (old_v - mean) * (old_v - mean);
 			jr = jrb_prev(jr);
 		}
@@ -303,8 +294,6 @@ int IsRareBMBPHigh(BMBPPred *p,
 	int highcount;
 	int lowcount;
 	double t;
-	int ndx;
-	double *vals;
 	double old_ts;
 	int found;
 	double old_v;
@@ -331,12 +320,10 @@ int IsRareBMBPHigh(BMBPPred *p,
 	 * walk backward in the history list and find the spot
 	 */
 	found = 0;
-	vals = GetFieldValues(p->data->data,J_TS);
 	jrb_rtraverse(jr,p->data->age_list)
 	{
-		ndx = jval_i(jrb_val(jr));
-		old_ts = vals[ndx];
-		if(old_ts <= ts)
+		HistoryPoint *historyPoint = (HistoryPoint *)jval_v(jrb_val(jr));
+		if(historyPoint->ts <= ts)
 		{
 			found = 1;
 			break;
@@ -364,15 +351,11 @@ int IsRareBMBPHigh(BMBPPred *p,
 	last_ts = -1;
 	while(jr != jrb_nil(p->data->age_list))
 	{
-		ndx = jval_i(jrb_val(jr));
-		vals = GetFieldValues(p->data->data,J_TS);
-		old_ts = vals[ndx];
-		vals = GetFieldValues(p->data->data,J_VALUE);
-		old_v = vals[ndx];
-		vals = GetFieldValues(p->data->data,J_HIGHPRED);
-		old_hp = vals[ndx];
-		vals = GetFieldValues(p->data->data,J_LOWPRED);
-		old_lp = vals[ndx];
+		HistoryPoint *historyPoint = (HistoryPoint *)jval_v(jrb_val(jr));
+		old_ts = historyPoint->ts;
+		old_v = historyPoint->value;
+		old_hp = historyPoint->highpred;
+		old_lp = historyPoint->lowpred;
 
 //		if((UseLow == 0) && ((old_v > old_hp) || (old_v < old_lp)))
 		/*
@@ -426,11 +409,10 @@ int IsRareBMBPHigh(BMBPPred *p,
 		total = 0;
 		count = 0;
 		jr = start_jr;
-		vals = GetFieldValues(p->data->data,J_VALUE);
 		while(jr != jrb_nil(p->data->age_list))
 		{
-			ndx = jval_i(jrb_val(jr));
-			old_v = vals[ndx];
+			HistoryPoint *historyPoint = (HistoryPoint *)jval_v(jrb_val(jr));
+			old_v = historyPoint->value;
 			total += old_v;
 			count++;
 			jr = jrb_prev(jr);
@@ -438,11 +420,10 @@ int IsRareBMBPHigh(BMBPPred *p,
 		mean = total / count;
 		total_v = 0;
 		jr = start_jr;
-		vals = GetFieldValues(p->data->data,J_VALUE);
 		while(jr != jrb_nil(p->data->age_list))
 		{
-			ndx = jval_i(jrb_val(jr));
-			old_v = vals[ndx];
+			HistoryPoint *historyPoint = (HistoryPoint *)jval_v(jrb_val(jr));
+			old_v = historyPoint->value;
 			total_v += (old_v - mean) * (old_v - mean);
 			jr = jrb_prev(jr);
 		}

--- a/src/schmib_q/bmbp_pred.h
+++ b/src/schmib_q/bmbp_pred.h
@@ -25,6 +25,8 @@ typedef struct bmbp_stc BMBPPred;
 
 
 void *InitBMBPPred(double quantile, double confidence, int fields);
+void *LoadBMBPPred(double quantile, double confidence, int fields, FILE *fd);
+void SaveBMBPPred(void *ib, FILE *fd);
 void FreeBMBPPred(void *ib);
 void UpdateBMBPPred(void *ib, double ts, double value, double lowpred, double highpred);
 int ForcBMBPPred(void *ib, double *lowpred, double *highpred);

--- a/src/schmib_q/bmbp_ts.c
+++ b/src/schmib_q/bmbp_ts.c
@@ -407,30 +407,30 @@ int main(int argc, char *argv[])
 				low_success++;
 			}
 			total++;
-			fprintf(stdout,"time: %10.0f ",ts);
-			fprintf(stdout,"value: %f ",value);
+			fprintf(stdout, "time: %10.0f ", ts);
+			fprintf(stdout, "value: %f ", value);
 			if(UseLow == 1) {
-	      		fprintf(stdout,"pred: %f ",low_pred_value);
+	      		fprintf(stdout, "pred: %f ", low_pred_value);
 			} else {
-	      		fprintf(stdout,"pred: %f ",pred_value);
+	      		fprintf(stdout, "pred: %f ", pred_value);
 			}
-	      	fprintf(stdout,"count: %d ",SizeOfBMBPPred(bp));
+	      	fprintf(stdout, "count: %d ", SizeOfBMBPPred(bp));
 			if(UseLow == 1) {
-	      			fprintf(stdout,"success: %f ",low_success);
+	      			fprintf(stdout, "success: %f ", low_success);
 			} else {
-	      			fprintf(stdout,"success: %f ",high_success);
+	      			fprintf(stdout, "success: %f ", high_success);
 			}
-	      		fprintf(stdout,"total: %f ",total);
+	      		fprintf(stdout, "total: %f ", total);
 			if(UseLow == 1) {
-				fprintf(stdout,"percent: %f\n",
+				fprintf(stdout, "percent: %f\n",
 						low_success/total);
 			} else {
-				fprintf(stdout,"percent: %f\n",
+				fprintf(stdout, "percent: %f\n",
 						high_success/total);
 			}
 			if(InvertValue != 0) {
-				fprintf(stdout,"lowp: %f\n",lowp);
-				fprintf(stdout,"highp: %f\n",highp);
+				fprintf(stdout, "lowp: %f\n", lowp);
+				fprintf(stdout, "highp: %f\n", highp);
 			}
 			fprintf(stdout,"\n");
 		}

--- a/src/schmib_q/jbindex.c
+++ b/src/schmib_q/jbindex.c
@@ -146,14 +146,14 @@ int JBIndex(int size, double quantile, double confidence, double *ratio)
 
   if(FindJBIndex(quantile,confidence,size,&index,ratio))
   {
-	return(index);
+	  return(index);
   }
 
   if(size > 500)
   {
-	idx = JBApprox(size,quantile,confidence);
-	*ratio = 0.0;
-	return(idx);
+    idx = JBApprox(size,quantile,confidence);
+    *ratio = 0.0;
+    return(idx);
   }
 
   if(size > 200)
@@ -189,8 +189,6 @@ int JBIndex(int size, double quantile, double confidence, double *ratio)
   mpf_out_str(stdout, 10, 10, c);
   printf(" ");
    */
-    
-  
 
   for (mpf_init_set_ui(j, 0);  mpf_cmp(n, j); mpf_add_ui(j, j, 1)) {
 

--- a/src/schmib_q/makefile
+++ b/src/schmib_q/makefile
@@ -2,11 +2,11 @@ CC = gcc
 #INC = -I. -Igmp-4.2.1/include
 INC = -I. -Igmp-6.0.0/include
 OBJS = jrb.o jval.o fbuff.o simple_input.o ecdf.o weibull.o weibpred.o hyperexp.o hyppred.o autoc.o lognpred.o matlabhack.o logupred.o
-SCHMIBOBJS = schmib_history.o schmib_q_sim.o schmib-means.o schmib_pred.o\
+SCHMIBOBJS = schmib_history.o schmib_q_sim.o schmib-means.o \
 	bmbp_pred.o dllist.o sim_history.o
 BMBPOBJS = schmib_history.o bmbp_pred.o schmib_q_sim.o
 INCLS = fbuff.h jrb.h jval.h norm.h simple_input.h jbindex.h\
-	rare_event.h ecdf.h weibull.h weibpred.h schmib_pred.h\
+	rare_event.h ecdf.h weibull.h weibpred.h \
 	schmib_history.h bmbp_pred.h schmib-means.h sim_history.h
 #GMPLIB = gmp-4.2.1/lib/libgmp.a
 GMPLIB = gmp-6.0.0/lib/libgmp.a
@@ -15,15 +15,15 @@ LIBS = ${GMPLIB} ./norm.o -lm
 NGLIBS = ./norm.o -lm
 CFLAGS = -g $(INC)
 
-all: schmib_sim bmbp_sim glrt_cluster exp_cluster bmbp_ts bmbp_index bmbp_steady cluster_ts\
-	spruce_sim machine_analysis logn_ts
+all: bmbp_sim glrt_cluster exp_cluster bmbp_ts bmbp_index bmbp_steady cluster_ts\
+	 machine_analysis logn_ts
 
-schmib_sim: schmib_sim.c $(OBJS) $(INCLS) ${GMPLIB} ${GMPOBJS} $(SCHMIBOBJS)\
-	 ./norm.o ./schmib-glrt.o
-	rm -f schmib_q_sim.o
-	${CC} ${CFLAGS} -g -c -DDOWN_TIME schmib_q_sim.c
-	${CC} ${CFLAGS} -DDOWN_TIME -o schmib_sim schmib_sim.c $(SCHMIBOBJS) $(OBJS) schmib-glrt.o ${GMPOBJS} $(LIBS)
-	${CC} ${CFLAGS} -g -c schmib_q_sim.c
+# schmib_sim: schmib_sim.c $(OBJS) $(INCLS) ${GMPLIB} ${GMPOBJS} $(SCHMIBOBJS)\
+# 	 ./norm.o ./schmib-glrt.o
+# 	rm -f schmib_q_sim.o
+# 	${CC} ${CFLAGS} -g -c -DDOWN_TIME schmib_q_sim.c
+# 	${CC} ${CFLAGS} -DDOWN_TIME -o schmib_sim schmib_sim.c $(SCHMIBOBJS) $(OBJS) schmib-glrt.o ${GMPOBJS} $(LIBS)
+# 	${CC} ${CFLAGS} -g -c schmib_q_sim.c
 
 spruce_sim: spruce_sim.c $(OBJS) $(INCLS) ${GMPLIB} ${GMPOBJS} $(SCHMIBOBJS)\
 	 ./norm.o ./schmib-glrt.o
@@ -49,13 +49,13 @@ machine_analysis: machine_analysis.c $(INCLS) $(INCLS) ${GMPLIB}\
 	 ${GMPOBJS} $(BMBPOBJS) norm.o
 	${CC} ${CFLAGS} -o machine_analysis machine_analysis.c $(BMBPOBJS) $(OBJS) ${GMPOBJS} $(LIBS)
 
-glrt_cluster: schmib-glrt.c $(OBJS) $(INCLS) schmib-means.o
+glrt_cluster: schmib-glrt.c $(OBJS) $(INCLS) schmib-means.o ${SCHMIBOBJS}
 	${CC} ${CFLAGS} -DTEST -o glrt_cluster schmib-glrt.c schmib-means.o jval.o jrb.o dllist.o simple_input.o $(LIBS)
 
-exp_cluster: schmib-means.c $(OBJS) $(INCLS)
+exp_cluster: schmib-means.c $(OBJS) $(INCLS) ${SCHMIBOBJS}
 	${CC} ${CFLAGS} -DTEST -o exp_cluster schmib-means.c jval.o jrb.o dllist.o simple_input.o $(NGLIBS)
 
-cluster_ts: schmib-means.o $(OBJS) $(INCLS) cluster_ts.c
+cluster_ts: schmib-means.o $(OBJS) $(INCLS) cluster_ts.c ${SCHMIBOBJS}
 	${CC} ${CFLAGS} cluster_ts.c -o cluster_ts schmib-means.o jval.o jrb.o dllist.o simple_input.o $(NGLIBS)
 
 jrb.o: jrb.c jval.h jrb.h

--- a/src/schmib_q/makefile
+++ b/src/schmib_q/makefile
@@ -13,7 +13,7 @@ GMPLIB = gmp-6.0.0/lib/libgmp.a
 GMPOBJS = jbindex.o mpf_comb.o rare_event.o
 LIBS = ${GMPLIB} ./norm.o -lm
 NGLIBS = ./norm.o -lm
-CFLAGS = -g $(INC)
+CFLAGS = -g $(INC) -O3 -finline-functions
 
 all: bmbp_sim glrt_cluster exp_cluster bmbp_ts bmbp_index bmbp_steady cluster_ts\
 	 machine_analysis logn_ts

--- a/src/schmib_q/rare_event.c
+++ b/src/schmib_q/rare_event.c
@@ -174,14 +174,14 @@ int ConsecutiveWrongRight(History *h, double *retautoc,
   sorted = make_jrb();
   if(sorted == NULL)
   {
-	exit(1);
+	  exit(1);
   }
 
   for (i=start; i<=GetHistorySize(h); i++)
   {
-    	GetHistoryEntry(h, i, &ts, &value, &dummy, &dummya, &dummyb,
-		&dummyc, &dummyd);
-	jrb_insert_dbl(sorted,ts,new_jval_i(i));
+    GetHistoryEntry(h, i, &ts, &value, &dummy, &dummya, &dummyb,
+		    &dummyc, &dummyd);
+	  jrb_insert_dbl(sorted,ts,new_jval_i(i));
   }
   count = 0; 
   //  printf("START: %d STOP: %d\n", start, GetHistorySize(h));

--- a/src/schmib_q/schmib_history.c
+++ b/src/schmib_q/schmib_history.c
@@ -29,7 +29,9 @@ History *MakeHistory(int fields)
 	{
 		exit(1);
 	}
+	bzero(h, sizeof(History));
 
+	
 	h->value_list = make_jrb();
 	if(h->value_list == NULL)
 	{
@@ -42,15 +44,7 @@ History *MakeHistory(int fields)
 		exit(1);
 	}
 
-	h->count = 0;
-	err = InitDataSet(&h->data,fields);
-	if(err == 0)
-	{
-		jrb_free_tree(h->value_list);
-		jrb_free_tree(h->age_list);
-		free(h);
-		return(NULL);
-	}
+	h->count = 0;	
 
 	return(h);
 }
@@ -65,32 +59,20 @@ void SaveHistory(History* h, FILE *fd)
 	// step 1: save out the struct itself
 	History copy;
 	memcpy(&copy, h, sizeof(History));
-	copy.data = NULL;
+	// copy.data = NULL;
 	copy.age_list = NULL;
 	copy.value_list = NULL;
 	fwrite(&copy, sizeof(History), 1, fd);
-
-	// step 2: save out the age list red black tree
-	JRB ptr;
-    jrb_traverse(ptr, h->age_list)
-    {
-        fputc(1, fd);
-        fwrite(&ptr->key, sizeof(Jval), 1, fd);
-        fwrite(&ptr->val, sizeof(Jval), 1, fd);
-    }
-    fputc(0, fd);
-
-	// step 3: save out the value list red black tree
-    jrb_traverse(ptr, h->value_list)
-    {
-        fputc(1, fd);
-        fwrite(&ptr->key, sizeof(Jval), 1, fd);
-        fwrite(&ptr->val, sizeof(Jval), 1, fd);
-    }
-	fputc(0, fd);
 	
-	// step 4: write out the history data set
-	SaveBinaryDataSet(h->data, fd);
+	// step 2: save out all of the history points
+	JRB ptr;
+	jrb_traverse(ptr, h->age_list)
+	{
+		HistoryPoint* hP = (HistoryPoint *)jval_v(jrb_val(ptr));
+		fputc(1, fd);
+		fwrite(hP, sizeof(HistoryPoint), 1, fd);
+	}
+	fputc(0, fd);
 
 #ifdef DEBUG_SAVE_RESTORE
 	fputc(0x02, fd);
@@ -111,32 +93,19 @@ History *LoadHistory(int fields, FILE *fd)
 	h = (History *)malloc(sizeof(History));
 	fread(h, sizeof(History), 1, fd);
 
-	// step 2: read the age list
 	JRB age_list = make_jrb();
-	while (fgetc(fd)) 
+	JRB value_list = make_jrb();
+
+	while (fgetc(fd))
 	{
-		Jval key, val;
-		fread(&key, sizeof(Jval), 1, fd);
-		fread(&val, sizeof(Jval), 1, fd);
-		jrb_insert_dbl(age_list, jval_d(key), val);
+		HistoryPoint *hP = (HistoryPoint *)malloc(sizeof(HistoryPoint));
+		fread(hP, sizeof(HistoryPoint), 1, fd);
+		jrb_insert_dbl(age_list, hP->ts, new_jval_v((void *)hP));
+		jrb_insert_dbl(value_list, hP->value, new_jval_v((void *)hP));
 	}
 
 	h->age_list = age_list;
-
-	// step 3: read the value list
-	JRB value_list = make_jrb();
-	while (fgetc(fd)) 
-	{
-		Jval key, val;
-		fread(&key, sizeof(Jval), 1, fd);
-		fread(&val, sizeof(Jval), 1, fd);
-		jrb_insert_dbl(value_list, jval_d(key), val);
-	}
 	h->value_list = value_list;
-
-	// step 4: read in the history data set
-	LoadBinaryDataSet(&(h->data), fields, fd);
-	assert(h->data != NULL);
 
 #ifdef DEBUG_SAVE_RESTORE 
 	assert(fgetc(fd) == 0x02);
@@ -151,12 +120,21 @@ void FreeHistory(History *h)
 	JRB curr;
 
 	/*
+	 * free all of the data points...
+	 */
+	jrb_traverse(curr, h->age_list)
+	{
+		HistoryPoint *p = (HistoryPoint *)jval_v(jrb_val(curr));
+		free(p);
+	}
+
+	/*
 	 * free the value list first
 	 */
 	jrb_free_tree(h->value_list);
 	jrb_free_tree(h->age_list);
 
-	FreeDataSet(h->data);
+	// FreeDataSet(h->data);
 
 	free(h);
 
@@ -171,34 +149,43 @@ void AddToHistory(History *h, double ts,
 	int last;
 	double values[7];
 
-	last = SizeOf(h->data) - 1;
-	Seek(h->data,last);
+	// last = SizeOf(h->data) - 1;
+	// Seek(h->data,last);
 
 	/*
 	 * last argument is a dummy for expansion purposes
 	 */
-	values[0] = ts;
-	values[1] = value;
-	values[2] = lowpred;
-	values[3] = highpred;
-	values[4] = exp_value;
-	values[5] = node_count;
-	values[6] = exec_time;
+	// values[0] = ts;
+	// values[1] = value;
+	// values[2] = lowpred;
+	// values[3] = highpred;
+	// values[4] = exp_value;
+	// values[5] = node_count;
+	// values[6] = exec_time;
 	/*
 	WriteEntry7(h->data,ts,value,lowpred,highpred,exp_value,node_count,
 		exec_time);
 	*/
-	WriteData(h->data,7,values);
-	index = Current(h->data);
+	// WriteData(h->data,7,values);
+	// index = Current(h->data);
+
+	HistoryPoint *p = (HistoryPoint *)malloc(sizeof(HistoryPoint));
+	p->ts = ts;
+	p->value = value;
+	p->lowpred = lowpred;
+	p->highpred = highpred;
+	p->exp = exp_value;
+	p->nodecount = node_count;
+	p->exectime = exec_time;
 
 	/*
 	 * sort value list by values
 	 */
-	(void) jrb_insert_dbl(h->value_list,value,new_jval_i(index));
+	jrb_insert_dbl(h->value_list, value, new_jval_v((void *)p));
 	/*
 	 * sort age list by ts
 	 */
-	jrb_insert_dbl(h->age_list,ts,new_jval_i(index));
+	jrb_insert_dbl(h->age_list,ts,new_jval_v((void *)p));
 	h->count++;
 
 	return;
@@ -236,11 +223,11 @@ double GetHistoryValue(History *h, int index)
 		curr = jrb_last(h->value_list);
 	}
 
-	i = jval_i(jrb_val(curr));
-	vals = GetFieldValues(h->data,J_VALUE);
-	value = vals[i];
+	HistoryPoint *p = (HistoryPoint *)jval_v(jrb_val(curr));
+	// vals = GetFieldValues(h->data,J_VALUE);
+	// value = vals[i];
 
-	return(value);
+	return(p->value);
 }
 
 double GetHistoryAge(History *h, int index)
@@ -266,12 +253,12 @@ double GetHistoryAge(History *h, int index)
 		curr = jrb_last(h->age_list);
 	}
 
-	i = jval_i(jrb_val(curr));
-	vals = GetFieldValues(h->data,J_TS);
-	ts = vals[i];
+	HistoryPoint *p = (HistoryPoint *)jval_v(jrb_val(curr));
 
-
-	return(ts);
+	// i = jval_i(jrb_val(curr));
+	// vals = GetFieldValues(h->data,J_TS);
+	// ts = vals[i];
+	return(p->ts);
 }		
 
 int GetHistoryEntry(History *h, int index, double *ts, double *value, 
@@ -312,34 +299,42 @@ double *exec_time)
 		curr = jrb_last(h->age_list);
 	}
 
-	i = jval_i(jrb_val(curr));
-	
+	// i = jval_i(jrb_val(curr));
+	HistoryPoint *p = jval_v(jrb_val(curr));
 
-	vals = GetFieldValues(h->data,J_TS);
-	*ts = vals[i];
-	vals = GetFieldValues(h->data,J_VALUE);
-	*value = vals[i];
-	vals = GetFieldValues(h->data,J_HIGHPRED);
-	*highpred = vals[i];
-	vals = GetFieldValues(h->data,J_LOWPRED);
-	*lowpred = vals[i];
+	// vals = GetFieldValues(h->data,J_TS);
+	// *ts = vals[i];
+	// vals = GetFieldValues(h->data,J_VALUE);
+	// *value = vals[i];
+	// vals = GetFieldValues(h->data,J_HIGHPRED);
+	// *highpred = vals[i];
+	// vals = GetFieldValues(h->data,J_LOWPRED);
+	// *lowpred = vals[i];
+	*ts = p->ts;
+	*value = p->value;
+	*highpred = p->highpred;
+	*lowpred = p->lowpred;
+
 	/*
 	 * not used if we are not doing clustering
 	 */
 	if(exp_value != NULL)
 	{
-		vals = GetFieldValues(h->data,J_EXP);
-		*exp_value = vals[i];
+		// vals = GetFieldValues(h->data,J_EXP);
+		// *exp_value = vals[i];
+		*exp_value = p->value;
 	}
 	if(node_count != NULL)
 	{
-		vals = GetFieldValues(h->data,J_NODECOUNT);
-		*node_count = vals[i];
+		// vals = GetFieldValues(h->data,J_NODECOUNT);
+		// *node_count = vals[i];
+		*node_count = p->nodecount;
 	}
 	if(exec_time != NULL)
 	{
-		vals = GetFieldValues(h->data,J_EXECTIME);
-		*exec_time = vals[i];
+		// vals = GetFieldValues(h->data,J_EXECTIME);
+		// *exec_time = vals[i];
+		*exec_time = p->exectime;
 	}
 	return(1);
 }
@@ -355,7 +350,6 @@ void TrimHistoryValue(History *h, int count)
 	double *vals;
 	double *time_vals;
 	double value;
-	int vindex;
 
 	/*
 	 * possible optimization: if the values in the data
@@ -381,32 +375,24 @@ void TrimHistoryValue(History *h, int count)
 	}
 
 	i = list_size;
-	vals = GetFieldValues(h->data,J_VALUE);
-	time_vals = GetFieldValues(h->data,J_TS);
+	// vals = GetFieldValues(h->data,J_VALUE);
+	// time_vals = GetFieldValues(h->data,J_TS);
 	jrb_traverse(curr,h->age_list)
 	{
-		
-		ndx = jval_i(jrb_val(curr));
-		value = vals[ndx];
+		HistoryPoint *p = (HistoryPoint *)jval_v(jrb_val(curr));
+		// ndx = jval_i(jrb_val(curr));
+		// value = vals[ndx];
 		/*  FIX ME!
 		value_entry = jrb_find_dbl(h->value_list,value);
 		vindex = jval_i(jrb_val(value_entry));
 		 */
+
 		value_entry = jrb_first(h->value_list);
-		vindex = jval_i(jrb_val(value_entry));
-		while(vindex != ndx)
+		while (value_entry != NULL && jval_v(jrb_val(value_entry)) != p)
 		{
 			value_entry = value_entry->flink;
-			vindex = jval_i(jrb_val(value_entry));
 		}
-		if(vindex != ndx)
-		{
-			fprintf(stderr,"error: couldn't find value entry\n");
-			fflush(stderr);
-			exit(1);
-		}
-		
-			
+
 		if(value_entry == NULL)
 		{
 			fprintf(stderr,
@@ -419,10 +405,16 @@ void TrimHistoryValue(History *h, int count)
 		 * delete the value node from the value list
 		 */
 		jrb_delete_node(value_entry);
+
 		/*
 		 * delete the node from the age list
 		 */
 		tempj = curr->blink;
+
+		/*
+		 * free the HistoryPoint struct associated with the node being trimmed
+		 */
+		free((HistoryPoint *)jval_v(jrb_val(curr)));
 
 		/*
 		 * delete the age record
@@ -438,7 +430,6 @@ void TrimHistoryValue(History *h, int count)
 
 		if(i <= 0)
 			break;
-
 	}
 
 	return;
@@ -453,7 +444,6 @@ void TrimHistoryAge(History *h, double oldest, int min)
 	double *vals;
 	double value;
 	double ts;
-	int vindex;
 
 	if(jrb_empty(h->age_list))
 		return;
@@ -464,43 +454,64 @@ void TrimHistoryAge(History *h, double oldest, int min)
 
 	jrb_traverse(curr,h->age_list)
 	{
-		vals = GetFieldValues(h->data,J_VALUE);
-		ndx = jval_i(jrb_val(curr));
-		value = vals[ndx];
+		HistoryPoint *p = (HistoryPoint *)jval_v(jrb_val(curr));
 
 		value_entry = jrb_first(h->value_list);
-		vindex = jval_i(jrb_val(value_entry));
-		while(vindex != ndx)
+		while(value_entry != NULL && jval_v(jrb_val(value_entry)) != p)
 		{
 			value_entry = value_entry->flink;
-			vindex = jval_i(jrb_val(value_entry));
-		}
-		if(vindex != ndx)
-		{
-			fprintf(stderr,"error: couldn't find value entry\n");
-			fflush(stderr);
-			exit(1);
-		}
-		if(value_entry == NULL)
-		{
-			fprintf(stderr,
-				"WARNING: missing value in trim\n");
-			fflush(stderr);
 		}
 
-		vals = GetFieldValues(h->data,J_TS);
-		ts = vals[ndx];
+		if (value_entry == NULL)
+		{
+			fprintf(stderr, "WARNING: missing value in trim\n");
+			fflush(stderr);
+			exit(1);
+		} 
+
+		// vals = GetFieldValues(h->data,J_VALUE);
+		// ndx = jval_i(jrb_val(curr));
+		// value = vals[ndx];
+
+		// value_entry = jrb_first(h->value_list);
+		// vindex = jval_i(jrb_val(value_entry));
+		// while(vindex != ndx)
+		// {
+		// 	value_entry = value_entry->flink;
+		// 	vindex = jval_i(jrb_val(value_entry));
+		// }
+		// if(vindex != ndx)
+		// {
+		// 	fprintf(stderr,"error: couldn't find value entry\n");
+		// 	fflush(stderr);
+		// 	exit(1);
+		// }
+		// if(value_entry == NULL)
+		// {
+		// 	fprintf(stderr,
+		// 		"WARNING: missing value in trim\n");
+		// 	fflush(stderr);
+		// }
+
+		// vals = GetFieldValues(h->data,J_TS);
+		// ts = vals[ndx];
 
 		/*
 		 * ties don't count
 		 */
-		if(ts > oldest)
+		if(p->ts > oldest)
 			break;
 
 		/*
 		 * delete the node from the value list
 		 */
 		jrb_delete_node(value_entry);
+		
+		/*
+		 * free the HistoryPoint struct associated with the node being trimmed
+		 */
+		free((HistoryPoint *)jval_v(jrb_val(curr)));
+		
 		/*
 		 * delete the node from the age list
 		 */
@@ -532,37 +543,45 @@ double *highpred, double *exp_value, double *node_count, double *exec_time)
 	}
 
 	first = jrb_first(h->age_list);
-	ndx = jval_i(jrb_val(first));
+	HistoryPoint *p = (HistoryPoint *)jval_v(jrb_val(first));
+	// ndx = jval_i(jrb_val(first));
 
-	vals = GetFieldValues(h->data,J_TS);
-	*ts = vals[ndx];
+	// vals = GetFieldValues(h->data,J_TS);
+	// *ts = vals[ndx];
+	*ts = p->ts;
 
-	vals = GetFieldValues(h->data,J_VALUE);
-	*value = vals[ndx];
+	// vals = GetFieldValues(h->data,J_VALUE);
+	// *value = vals[ndx];
+	*value = p->value;
 
-	vals = GetFieldValues(h->data,J_HIGHPRED);
-	*highpred = vals[ndx];
+	// vals = GetFieldValues(h->data,J_HIGHPRED);
+	// *highpred = vals[ndx];
+	*highpred = p->highpred;
 
-	vals = GetFieldValues(h->data,J_LOWPRED);
-	*lowpred = vals[ndx];
+	// vals = GetFieldValues(h->data,J_LOWPRED);
+	// *lowpred = vals[ndx];
+	*lowpred = p->lowpred;
 
 	/*
 	 * not used if we are not doing clustering
 	 */
 	if(exp_value != NULL)
 	{
-		vals = GetFieldValues(h->data,J_EXP);
-		*exp_value = vals[ndx];
+		// vals = GetFieldValues(h->data,J_EXP);
+		// *exp_value = vals[ndx];
+		*exp_value = p->exp;
 	}
 	if(node_count != NULL)
 	{
-		vals = GetFieldValues(h->data,J_NODECOUNT);
-		*node_count = vals[ndx];
+		// vals = GetFieldValues(h->data,J_NODECOUNT);
+		// *node_count = vals[ndx];
+		*node_count = p->nodecount;
 	}
 	if(exec_time != NULL)
 	{
-		vals = GetFieldValues(h->data,J_EXECTIME);
-		*exec_time = vals[ndx];
+		// vals = GetFieldValues(h->data,J_EXECTIME);
+		// *exec_time = vals[ndx];
+		*exec_time = p->exp;
 	}
 
 	return(1);
@@ -586,10 +605,12 @@ double *exec_time)
 	GetOldestHistory(h,ts,value,lowpred,highpred,exp_value,node_count,
 		exec_time);
 	first = jrb_first(h->age_list);
-	ndx = jval_i(jrb_val(first));
-	vals = GetFieldValues(h->data,J_VALUE);
-	v = vals[ndx];
-	value_entry = jrb_find_dbl(h->value_list,v);
+	
+	HistoryPoint *p = (HistoryPoint *)jval_v(jrb_val(first));
+	// ndx = jval_i(jrb_val(first));
+	// vals = GetFieldValues(h->data,J_VALUE);
+	// v = vals[ndx];
+	value_entry = jrb_find_dbl(h->value_list, p->value);
 	if(value_entry == NULL)
 	{
 		fprintf(stderr,
@@ -597,8 +618,10 @@ double *exec_time)
 		fflush(stderr);
 	}
 	
+	free(p);
 	jrb_delete_node(value_entry);
 	jrb_delete_node(first);
+
 	h->count--;
 
 	return;
@@ -609,14 +632,12 @@ void PrintHistoryValue(History *h, int ts_field, int val_field)
 	JRB jr;
 	double *ts_vals;
 	double *vals;
-	int ndx;
+	HistoryPoint *p;
 
-	ts_vals = GetFieldValues(h->data, ts_field);
-	vals = GetFieldValues(h->data,val_field);
 	jrb_traverse(jr,h->value_list)
 	{
-		ndx = jval_i(jrb_val(jr));
-		fprintf(stdout,"\t%f %f %d\n",ts_vals[ndx],vals[ndx],ndx);
+		p = jval_v(jrb_val(jr));
+		fprintf(stdout,"\t%f %f\n",p->ts,p->value);
 	}
 
 	return;

--- a/src/schmib_q/schmib_history.c
+++ b/src/schmib_q/schmib_history.c
@@ -17,7 +17,7 @@
 
 #include "schmib_history.h"
 
-#define DEBUG_SAVE_RESTORE 1
+#define DEBUG_SAVE_RESTORE 0
 
 History *MakeHistory(int fields)
 {
@@ -190,7 +190,6 @@ void AddToHistory(History *h, double ts,
 	*/
 	WriteData(h->data,7,values);
 	index = Current(h->data);
-
 
 	/*
 	 * sort value list by values

--- a/src/schmib_q/schmib_history.c
+++ b/src/schmib_q/schmib_history.c
@@ -206,7 +206,7 @@ double GetHistoryValue(History *h, int index)
 	// uccess_percentage: 0.977571
 	// 4.23 real         4.01 user         0.07 sys
 
-	if (index < h->count / 2) // optimizer should turn /2 into << 
+	if (index <= h->count / 2)
 	{
 		count = 1;
 		jrb_traverse(curr,h->value_list)
@@ -216,27 +216,21 @@ double GetHistoryValue(History *h, int index)
 	
 			count++;
 		}
-	
-		if(curr == NULL)
-		{
-			curr = jrb_last(h->value_list);
-		}
-	}
-	else
+	} 
+	else 
 	{
 		count = h->count;
-
 		jrb_rtraverse(curr, h->value_list)
 		{
 			if (count <= index)
 				break;
 			count--;
 		}
+	}
 
-		if (curr == NULL)
-		{
-			curr = jrb_first(h->value_list);
-		}
+	if (curr == NULL)
+	{
+		curr = jrb_last(h->value_list);
 	}
 
 	
@@ -257,16 +251,29 @@ double GetHistoryAge(History *h, int index)
 	JRB curr;
 	JRB temp;
 
-	count = 1;
-	jrb_traverse(curr,h->age_list)
+	if (index <= h->count / 2)
 	{
-		if(count >= index)
-			break;
-
-		count++;
+		count = 1;
+		jrb_traverse(curr,h->age_list)
+		{
+			if(count >= index)
+				break;
+	
+			count++;
+		}
+	} 
+	else 
+	{
+		count = h->count;
+		jrb_rtraverse(curr, h->age_list)
+		{
+			if (count <= index)
+				break;
+			count--;
+		}
 	}
 
-	if(curr == NULL)
+	if (curr == NULL)
 	{
 		curr = jrb_last(h->age_list);
 	}
@@ -303,31 +310,37 @@ double *exec_time)
 		return(0);
 	}
 
-	count = 1;
-	jrb_traverse(curr,h->age_list)
+	if (index <= h->count / 2)
 	{
-		if(count >= index)
-			break;
-
-		count++;
+		count = 1;
+		jrb_traverse(curr,h->age_list)
+		{
+			if(count >= index)
+				break;
+	
+			count++;
+		}
+	} 
+	else 
+	{
+		count = h->count;
+		jrb_rtraverse(curr, h->age_list)
+		{
+			if (count <= index)
+				break;
+			count--;
+		}
 	}
 
-	if(curr == NULL)
+	if (curr == NULL)
 	{
 		curr = jrb_last(h->age_list);
 	}
+	
 
 	// i = jval_i(jrb_val(curr));
 	HistoryPoint *p = jval_v(jrb_val(curr));
 
-	// vals = GetFieldValues(h->data,J_TS);
-	// *ts = vals[i];
-	// vals = GetFieldValues(h->data,J_VALUE);
-	// *value = vals[i];
-	// vals = GetFieldValues(h->data,J_HIGHPRED);
-	// *highpred = vals[i];
-	// vals = GetFieldValues(h->data,J_LOWPRED);
-	// *lowpred = vals[i];
 	*ts = p->ts;
 	*value = p->value;
 	*highpred = p->highpred;

--- a/src/schmib_q/schmib_history.c
+++ b/src/schmib_q/schmib_history.c
@@ -193,12 +193,7 @@ void AddToHistory(History *h, double ts,
 
 int GetHistorySize(History *h)
 {
-	int list_size;
-	
-	list_size = h->count;
-
-	return(list_size);
-
+	return h->count;
 }
 
 double GetHistoryValue(History *h, int index)
@@ -208,20 +203,43 @@ double GetHistoryValue(History *h, int index)
 	int i;
 	double value;
 	JRB curr;
+	// uccess_percentage: 0.977571
+	// 4.23 real         4.01 user         0.07 sys
 
-	count = 1;
-	jrb_traverse(curr,h->value_list)
+	if (index < h->count / 2) // optimizer should turn /2 into << 
 	{
-		if(count >= index)
-			break;
+		count = 1;
+		jrb_traverse(curr,h->value_list)
+		{
+			if(count >= index)
+				break;
+	
+			count++;
+		}
+	
+		if(curr == NULL)
+		{
+			curr = jrb_last(h->value_list);
+		}
+	}
+	else
+	{
+		count = h->count;
 
-		count++;
+		jrb_rtraverse(curr, h->value_list)
+		{
+			if (count <= index)
+				break;
+			count--;
+		}
+
+		if (curr == NULL)
+		{
+			curr = jrb_first(h->value_list);
+		}
 	}
 
-	if(curr == NULL)
-	{
-		curr = jrb_last(h->value_list);
-	}
+	
 
 	HistoryPoint *p = (HistoryPoint *)jval_v(jrb_val(curr));
 	// vals = GetFieldValues(h->data,J_VALUE);

--- a/src/schmib_q/schmib_history.h
+++ b/src/schmib_q/schmib_history.h
@@ -39,15 +39,17 @@ int JobIndex;
 struct history_stc
 { 
 	void *data;		/* data set defined by simple_input */
-        JRB value_list;
-        JRB age_list;
+	JRB value_list;
+	JRB age_list;
 	int count;
 };
 
 typedef struct history_stc History;
 
 History *MakeHistory(int fields);
-void AddToHistory(History *h, double ts, double resp_value, 
+History *LoadHistory(int fields, FILE *fd);
+void SaveHistory(History *h, FILE *fd);
+void AddToHistory(History *h, double ts, double resp_value,
 		double lowpred, double highpred, double exp_value,
 		double node_count, double exec_time);
 int GetHistorySize(History *h);

--- a/src/schmib_q/schmib_history.h
+++ b/src/schmib_q/schmib_history.h
@@ -38,13 +38,28 @@ int JobIndex;
   
 struct history_stc
 { 
-	void *data;		/* data set defined by simple_input */
 	JRB value_list;
 	JRB age_list;
 	int count;
 };
 
 typedef struct history_stc History;
+
+struct history_data_point_stc 
+{
+	// TODO: convert the history data structure to use this such that it is effectively
+	// a linked list, not indexing into an array of records that grows in a strictly
+	// increasing manner
+	double ts;
+	double value;
+	double lowpred;
+	double highpred;
+	double exp;
+	double nodecount;
+	double exectime;
+};
+
+typedef struct history_data_point_stc HistoryPoint;
 
 History *MakeHistory(int fields);
 History *LoadHistory(int fields, FILE *fd);

--- a/src/schmib_q/simple_input.c
+++ b/src/schmib_q/simple_input.c
@@ -118,8 +118,6 @@ void SaveBinaryDataSet(void *cookie, FILE *fd)
 
 int LoadBinaryDataSet(void **cookie, int fields, FILE *fd)
 {
-	printf("Loading Binary Data Set\n");
-
 	DataSet *ds = (DataSet *)malloc(sizeof(DataSet));
 	fread(ds, sizeof(DataSet), 1, fd);
 
@@ -135,8 +133,6 @@ int LoadBinaryDataSet(void **cookie, int fields, FILE *fd)
 		bzero(ds->data[i], sizeof(double) * ds->space_size);
 		fread(ds->data[i], sizeof(double), ds->data_c, fd);
 	}
-
-	printf("Finish Loading Binary Dataset.\n");
 
 	*cookie = (void *)ds;
 

--- a/src/schmib_q/simple_input.h
+++ b/src/schmib_q/simple_input.h
@@ -31,6 +31,9 @@
 
 #define DEFAULT_BLOCKSIZE (50000)
 int InitDataSet(void **cookie, int fields);
+void SaveBinaryDataSet(void *cookie, FILE *fd);
+int LoadBinaryDataSet(void **cookie, int fields, FILE *fd);
+
 void FreeDataSet(void *cookie);
 void SetBlockSize(void *cookie, int size);
 int LoadDataSet(char *fname, void *cookie);

--- a/src/tests/make-test-data.py
+++ b/src/tests/make-test-data.py
@@ -1,0 +1,9 @@
+import random 
+count = 0
+with open('test.txt', 'wb') as f:
+    for x in range(0, 5):
+        offset = random.gauss(1000, 500)
+        for x in range(count, count + 5000):
+            line = "%d %d" % (x, offset + random.gauss(0, 200))
+            f.write((line + "\n").encode('ascii'))
+        count += 5000

--- a/src/tests/test-incremental-updates.py
+++ b/src/tests/test-incremental-updates.py
@@ -1,0 +1,105 @@
+import os 
+import subprocess
+import random 
+
+BIN = "../schmib_q/bmbp_ts"
+
+fulldataset = []
+for i in range(0, 10):
+    offset = random.gauss(10000, 1000)
+    dataset = [("%d %.4f\n" % (x, offset + random.gauss(1000, 300))).encode('ascii') for x in range(len(fulldataset), len(fulldataset) + 800)]
+    fulldataset.extend(dataset)
+
+def splitdataset(dataset, parts=2):
+    split_points = random.sample(range(1, len(fulldataset)), parts - 1)
+    split_points.sort()
+
+    fnames = []
+    last_point = 0
+    for point in split_points:
+        samples = fulldataset[last_point:point]
+        fname = "input-%d.txt" % point
+        with open(fname, 'wb') as f:
+            f.writelines(samples)
+        fnames.append(fname)
+        last_point = point 
+    
+    with open("therest.txt", "wb") as f:
+        f.writelines(fulldataset[last_point:])
+    fnames.append("therest.txt")
+    
+    return fnames 
+
+def run_bmbp_ts(fname, savestate=None, loadstate=None):
+    cmd = BIN + " -T --file " + fname + " --quantile 0.97 --confidence 0.01"
+    if savestate != None:
+        cmd += " --savestate " + savestate 
+    if loadstate != None:
+        cmd += " --loadstate " + loadstate
+    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+    return p
+
+def cleanup_files(dir, extension='.txt'):
+    filelist = [f for f in os.listdir(dir) if f.endswith(extension)]
+    for f in filelist:
+        os.remove(f)
+
+
+expected_success_percent = None 
+
+def test_can_run_bmbp_ts_on_dataset():
+    global expected_success_percent
+
+    with open("input.txt", "wb") as input:
+        input.writelines(fulldataset)
+    p = run_bmbp_ts("input.txt", savestate=None, loadstate=None)
+    output = p.stdout.read().decode('ascii').split("\n")
+    p.wait()
+    assert(p.returncode == 0)
+    expected_success_percent = output[-2]
+
+    print("Success percentage for full dataset:")
+    print(output[-2])
+
+def test_can_get_same_success_with_one_split():
+    with open("input1.txt", "wb") as input:
+        input.writelines(fulldataset[0:round(len(fulldataset) * 0.5)])
+    
+    with open("input2.txt", "wb") as input:
+        input.writelines(fulldataset[round(len(fulldataset) * 0.5):])
+
+    p = run_bmbp_ts("input1.txt", savestate="state.txt", loadstate=None)
+    p.stdout.read()
+    p.wait()
+    assert(p.returncode == 0)
+
+    p = run_bmbp_ts("input2.txt", savestate=None, loadstate="state.txt")
+    output = p.stdout.read().decode('ascii').split("\n")
+    p.wait()
+    assert(p.returncode == 0)
+
+    assert(output[-2] == expected_success_percent)
+    print("Success percentage with split at half way: ")
+    print(output[-2])
+
+def test_can_get_same_success_with_random_splits():
+    files = splitdataset(fulldataset, parts=10)
+
+    last_state = None
+    last_succ_percentage = None
+    for f in files:
+        print("\trunning fragment: %s" % f)
+        
+        p = run_bmbp_ts(f, savestate="state.txt", loadstate=last_state)
+        output = p.stdout.read().decode('ascii').split("\n")
+        p.wait()
+        assert(p.returncode == 0)
+
+        last_state = "state.txt"
+
+        print("\tfragment success percentage:")
+        print("\t\t" + output[-2])
+    
+        last_succ_percentage = output[-2]
+
+    assert(last_succ_percentage == expected_success_percent)


### PR DESCRIPTION
bmbp_ts can now take in incremental updates to its state

```sh
./bmbp_ts --file <input file> --quantile <quantile> --confidence <confidence> --savestate <a file to save the state to> --loadstate <a file to load the state from>
```

bmbp_ts has also been converted to take longargs since I couldn't think of names for the save and load state parameters better than 's' and 'S' so I figured this would be best to avoid confusion and bugs from the aforementioned confusion. 

In addition this pr includes code that...

Dramatically reduced the size of the BMBPPred state file dumps by only dumping the most recent part of the history that is still needed for predictions. Note that if trim is disabled this will have no effect. 

Note that this breaks certain other utilities in schmib_q which you can see have been removed from the makefile in this commit. 